### PR TITLE
Use the configuration specified in application.conf

### DIFF
--- a/src/main/scala/me/reminisce/server/Server.scala
+++ b/src/main/scala/me/reminisce/server/Server.scala
@@ -17,9 +17,9 @@ import scala.concurrent.duration.Duration
   */
 object Server extends App {
   // an ActorSystem to host our application in
-  implicit val system = ActorSystem("server")
-  implicit val context = ExecutionContext.Implicits.global
   val conf = ConfigFactory.load()
+  implicit val system = ActorSystem("server", conf)
+  implicit val context = ExecutionContext.Implicits.global
 
   val protocol = "http://"
   val hostName = ApplicationConfiguration.hostName


### PR DESCRIPTION
The Conf object issued by ConfigFactory.load() must be fed to the constructor of the actor system in order to use the settings specified in the application.conf file.