### PR TITLE
Remove usage of embedmongo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,15 @@ jdk:
 
 sudo: false
 
+services: mongodb
+
+addons:
+  apt:
+    sources:
+    - mongodb-3.2-precise
+    packages:
+    - mongodb-org-server
+
 cache:
   directories:
   - $HOME/.ivy2/cache

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@ libraryDependencies ++= {
   val reactiveMongoV = "0.11.14"
   val scalaTestV = "2.2.6"
   val sprayJsonV = "1.3.2"
-  val scalaTestEmbedmongoV = "0.2.3-SNAPSHOT"
   val nscalaTimeV = "2.10.0"
+  val slf4jSimpleV = "1.6.1"
 
   Seq(
     "org.reactivemongo" %% "reactivemongo" % reactiveMongoV,
@@ -35,7 +35,7 @@ libraryDependencies ++= {
     "org.json4s"          %% "json4s-native"  % json4sV,
     "org.json4s"          %% "json4s-jackson" % json4sV,
     "org.json4s"          %% "json4s-ext"     % json4sV,
-    "com.github.simplyscala" %% "scalatest-embedmongo" % scalaTestEmbedmongoV,
+    "org.slf4j" % "slf4j-simple" % slf4jSimpleV,
     "org.scala-lang" % "scala-reflect" % scalaVersion.value
   )
 }
@@ -65,6 +65,8 @@ resolvers ++= Seq("snapshots", "releases").map(Resolver.sonatypeRepo)
 resolvers ++= Seq("Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/")
 
 resolvers ++= Seq("Typesafe repository releases" at "http://repo.typesafe.com/typesafe/releases/")
+
+resolvers ++= Seq("Slf4j-simple" at "https://mvnrepository.com/artifact/org.slf4j/slf4j-simple")
 
 assemblyJarName in assembly := "game-creator.jar"
 

--- a/src/main/scala/me/reminisce/database/DeletionService.scala
+++ b/src/main/scala/me/reminisce/database/DeletionService.scala
@@ -127,9 +127,11 @@ class DeletionService(database: DefaultDB) extends Actor with ActorLogging {
     * @param client the original deletion requester
     */
   private def clearDatabase(client: ActorRef): Unit = {
-    foreachCollection(client) {
-      worker =>
-        worker ! DropCollection()
+    database.drop().onComplete {
+      case Success(_) =>
+        client ! Done("Deletion performed without error.")
+      case Failure(e) =>
+        client ! InternalError(s"Database error : $e.")
     }
   }
 

--- a/src/test/scala/me/reminisce/database/DatabaseTester.scala
+++ b/src/test/scala/me/reminisce/database/DatabaseTester.scala
@@ -33,10 +33,11 @@ abstract class DatabaseTester(actorSystemName: String) extends TestKit(ActorSyst
   protected def testWithDb(test: DefaultDB => Unit): Unit = {
     val dbId = Random.nextInt // if the actorSystemName is shared for unknown reasons.
     val connection = DatabaseTestHelper.getConnection
-    val dbName = s"DB${dbId}_for$actorSystemName"
+    val dbName = s"DB${dbId}_for_$actorSystemName"
 
     whenReady(connection.database(dbName, failoverStrategy = failoverStrategy)) {
       db =>
+        DatabaseTestHelper.registerDb(db)
         test(db)
     }
   }

--- a/src/test/scala/me/reminisce/server/ServerServiceActorSpec.scala
+++ b/src/test/scala/me/reminisce/server/ServerServiceActorSpec.scala
@@ -11,13 +11,15 @@ import spray.client.pipelining._
 import spray.http._
 
 import scala.concurrent.duration.Duration
+import scala.util.Random
 
 @DoNotDiscover
 class ServerServiceActorSpec extends DatabaseTester("ServerServiceActorSpec") {
 
   case class SimpleMessageFormat(message: String)
   val port = DatabaseTestHelper.port
-  val testService = TestActorRef(new ServerServiceActor(s"localhost:$port", "garbage"))
+  val dbId = Random.nextInt
+  val testService = TestActorRef(new ServerServiceActor(s"localhost:$port", s"DB${dbId}_for_ServerServiceActorSpec"))
 
   implicit def json4sFormats: Formats = DefaultFormats
 

--- a/utils/dropall.js
+++ b/utils/dropall.js
@@ -1,0 +1,8 @@
+// run this with
+// $ mongo dropall.js
+
+var dbs = db.getMongo().getDBNames();
+for(var i in dbs){
+	db = db.getMongo().getDB( dbs[i] );
+	db.dropDatabase();
+}


### PR DESCRIPTION
EmbedMongo was causign a lot of troubles, tests are now run on an actual
mongo instance:
- Remove EmbedMongo
- Add slf4j-simple because ReactiveMongo requires that one backend is
  there (some was imported by EmbedMongo)
- Add clear script in utils/
- Modify tests to make it all work
- Request to /dropDatabase no properly drops the database (instead of
  dropping collections individually)