### PR TITLE
Elastic logs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ libraryDependencies ++= {
     "org.slf4j" % "slf4j-api" % slf4jV,
     "ch.qos.logback" % "logback-core" % logbackV,
     "ch.qos.logback" % "logback-classic" % logbackV,
+    "net.logstash.logback" % "logstash-logback-encoder" % "4.7",
     "org.scala-lang" % "scala-reflect" % scalaVersion.value
   )
 }
@@ -75,6 +76,7 @@ resolvers ++= Seq("Typesafe repository releases" at "http://repo.typesafe.com/ty
 resolvers ++= Seq("slf4j on Maven" at "https://mvnrepository.com/artifact/org.slf4j/slf4j-api")
 resolvers ++= Seq("logback-core on Maven" at "https://mvnrepository.com/artifact/ch.qos.logback/logback-core")
 resolvers ++= Seq("logback-classic on Maven" at "https://mvnrepository.com/artifact/ch.qos.logback/logback-classic")
+resolvers ++= Seq("Logback logstash interface" at "https://mvnrepository.com/artifact/net.logstash.logback/logstash-logback-encoder")
 
 assemblyJarName in assembly := "game-creator.jar"
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -27,8 +27,13 @@
         <encoder>
             <pattern>%date{ISO8601} %level %logger [%file:%line] %msg%n</pattern>
         </encoder>
-
     </appender>
+
+    <appender name="logstash-tcp" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>127.0.0.1:4560</destination>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
 
     <!-- AsyncAppender logs ILoggingEvents asynchronously. It acts solely as an event dispatcher and must therefore
          reference another appender in order to do anything useful. It uses a queue, parameters can be set. Look at the doc -->
@@ -46,5 +51,6 @@
         <appender-ref ref="errorLog"/>
         <appender-ref ref="errorInfoLog"/>
         <appender-ref ref="completeLog"/>
+        <appender-ref ref="logstash-tcp"/>
     </root>
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -30,7 +30,7 @@
     </appender>
 
     <appender name="logstash-tcp" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <destination>127.0.0.1:4560</destination>
+        <destination>logstash:4560</destination>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
 


### PR DESCRIPTION
Logging events are streamed to logstash host which is reachable at `logstash:4560`.
If no logstash host is found at this address, an error is printed to stdout and execution continues.

An example of this error is

```
Log destination logstash:4560: connection failed. Waiting 29996ms before attempting reconnection. java.net.UnknownHostException: logstash
	at java.net.UnknownHostException: logstash
	at 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:184)
	at 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at 	at java.net.Socket.connect(Socket.java:589)
	at 	at net.logstash.logback.appender.AbstractLogstashTcpSocketAppender$TcpSendingEventHandler.openSocket(AbstractLogstashTcpSocketAppender.java:536)
	at 	at net.logstash.logback.appender.AbstractLogstashTcpSocketAppender$TcpSendingEventHandler.onStart(AbstractLogstashTcpSocketAppender.java:488)
	at 	at net.logstash.logback.appender.AsyncDisruptorAppender$EventClearingEventHandler.onStart(AsyncDisruptorAppender.java:332)
	at 	at net.logstash.logback.encoder.com.lmax.disruptor.BatchEventProcessor.notifyStart(BatchEventProcessor.java:185)
	at 	at net.logstash.logback.encoder.com.lmax.disruptor.BatchEventProcessor.run(BatchEventProcessor.java:114)
	at 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at 	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at 	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at 	at java.lang.Thread.run(Thread.java:745)
```