### PR TITLE
Remove information from question subject

### DIFF
--- a/src/main/scala/me/reminisce/gameboard/questions/QuestionGenerator.scala
+++ b/src/main/scala/me/reminisce/gameboard/questions/QuestionGenerator.scala
@@ -80,11 +80,25 @@ object QuestionGenerator {
       case Some(message) =>
         message + (if (includeStory) {
           post.story match {
-            case Some(story) => "\n" + story
+            case Some(story) => "\n" + stripInformation(story)
             case None => ""
           } 
         } else "")
-      case None => post.story.getOrElse("")
+      case None => stripInformation(post.story.getOrElse(""))
+    }
+  }
+
+  /**
+    * Strips the story from some information such as time, people or location.
+    * @param story a post story
+    * @return the transformed story
+    */
+  def stripInformation(story: String): String = {
+    story.split(" — ").toList match {
+      case str::Nil =>
+        str
+      case str :+ info =>
+        str.mkString(" — ")
     }
   }
 

--- a/src/test/scala/me/reminisce/gameboard/questions/QuestionGeneratorSuite.scala
+++ b/src/test/scala/me/reminisce/gameboard/questions/QuestionGeneratorSuite.scala
@@ -129,15 +129,16 @@ class QuestionGeneratorSuite extends FunSuite {
 
   test("Extracting text from post.") {
     val postMessage = "TestMessage"
-    val postStory = "Story"
+    val postStory = "Jacqueline Zumturm added 7 new photos — to the album: Salami — with Poulet Frit and 5 others."
+    val strippedStory = "Jacqueline Zumturm added 7 new photos — to the album: Salami"
 
     val testPostStoryMessage = createTestPost(postMessage, postStory, "ND")
     val storyMessage = QuestionGenerator.textFromPost(testPostStoryMessage)
-    assert(storyMessage == postMessage + "\n" + postStory)
+    assert(storyMessage == postMessage + "\n" + strippedStory)
 
     val testPostStoryOnly = createTestPost("", postStory, "ND")
     val storyOnly = QuestionGenerator.textFromPost(testPostStoryOnly)
-    assert(storyOnly == postStory)
+    assert(storyOnly == strippedStory)
 
     val testPostMessgaeOnly = createTestPost(postMessage, "", "ND")
     val messageOnly = QuestionGenerator.textFromPost(testPostMessgaeOnly)
@@ -146,6 +147,9 @@ class QuestionGeneratorSuite extends FunSuite {
     val testPostNoText = createTestPost("", "", "ND")
     val noText = QuestionGenerator.textFromPost(testPostNoText)
     assert(noText == "")
+
+    // This should not change
+    assert(QuestionGenerator.stripInformation("AA—AA—AA") == "AA—AA—AA")
   }
 
   test("Extracting src from FBAttachments.") {


### PR DESCRIPTION
This information could help answering the question in some cases.
Fixes #38 and fixes #64.